### PR TITLE
Test that demonstrates hotspot bug

### DIFF
--- a/EnvVarOptionsTest.java
+++ b/EnvVarOptionsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288483
+ * @summary Test that JAVA_TOOL_OPTIONS variable are hanled corectly ever if they exceed 1024 bytes
+ * @library /testlibrary
+ * @run driver EnvVarOptionsTest
+ */
+
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.util.NoSuchElementException;
+
+import com.oracle.java.testlibrary.ProcessTools;
+import com.oracle.java.testlibrary.OutputAnalyzer;
+
+public class EnvVarOptionsTest {
+
+    /* Put more than 64 options to command line */
+    public static String CreateOptionsString(int items) {
+        StringBuilder vm_flags = new StringBuilder();
+        for (int i = 0; i < items; ++i) {
+           vm_flags.append(" -XX:+BO" + i);
+        }
+        return vm_flags.toString();
+    }
+
+    public static void runJavaWithOptions(String flags) throws Exception {
+        ProcessBuilder pb = null;
+        OutputAnalyzer output = null;
+
+        String[] envVars = {
+            "_JAVA_OPTIONS",
+            "JAVA_TOOL_OPTIONS"
+        };
+
+        for (String envVar :  envVars) {
+            System.out.println("Test " + envVar + " env-var");
+            pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintVMOptions",
+                                                       "-XX:+IgnoreUnrecognizedVMOptions", "-version");
+            pb.environment().put(envVar, flags);
+            output = new OutputAnalyzer(pb.start());
+            output.shouldContain("VM option '+BO66'");
+            output.shouldHaveExitValue(0);
+            output.reportDiagnosticSummary();
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+        // JVM will report
+        // [Picked up _JAVA_OPTIONS:  -XX:+BO0 ... -XX:+BO66]
+        // But only first 64 options are actually picked because of
+        // the hardcoded HotSpot limit
+        String flags = CreateOptionsString(67);
+        runJavaWithOptions(flags);
+
+        // JVM will ignore the variable
+        // with no clue of what is happening
+        flags = CreateOptionsString(1024);
+        runJavaWithOptions(flags);
+    }
+}


### PR DESCRIPTION
This testcase demonstrates ill behavior of HotSpot. 

If JAVA_TOOL_OPTIONS variable contains more that 64 options, only first 64 will be taken in account.
If JAVA_TOOL_OPTIONS is more than 1024 bytes long it will be silently ignored.

This testcase is not a part of PR because it doesn't exist in upstream. 
